### PR TITLE
Fix support for IPv6 inside the tunnel

### DIFF
--- a/lib/conf.js
+++ b/lib/conf.js
@@ -4,15 +4,17 @@ module.exports = ({ privateKey, publicKey, config }) =>
 PrivateKey = ${privateKey}
 # PublicKey = ${publicKey}
 Address = ${config.interface.addresses.v4}
-# Address = ${config.interface.addresses.v6}
+Address = ${config.interface.addresses.v6}
 DNS = 1.1.1.1
 
 [Peer]
 PublicKey = ${config.peers[0].public_key}
-Endpoint = ${config.peers[0].endpoint.v4}
+Endpoint = ${config.peers[0].endpoint.host}
+# Endpoint = ${config.peers[0].endpoint.v4}
 # Endpoint = ${config.peers[0].endpoint.v6}
-# Endpoint = ${config.peers[0].endpoint.host}
-AllowedIPs = 0.0.0.0/0`.slice(1)
+AllowedIPs = 0.0.0.0/0
+AllowedIPs = ::/0
+`.slice(1)
 if (require.main === module) {
 	require('get-stdin')()
 		.then(JSON.parse)


### PR DESCRIPTION
The generated config kills the IPv6 inside the tunnel for no reason.
This fix will allow IPv6 to go through the tunnel and also uses DNS
name for tunnel endpoint, which will help establishing the tunnel
in IPv6-only environments like mobile networks.