### PR TITLE
feat: support license binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ docker run --rm -v ~/.cf-warp:/root/.cf-warp maple3142/cf-warp [args]
 
 It currently get quota by faking referrers since there is no way to pay for premium version outside of 1.1.1.1 app, but it is recommended to pay for it on your phone if you think their service is good.
 
+### How do link this to a WARP+ license from the mobile 1.1.1.1 app?
+
+1. Find your license key on your mobile 1.1.1.1 app
+    - It should be under settings/account/key, in the form of "1a2b3d4e-1a2b3d4e-1a2b3d4e"
+2. Copy that key, and run the command:
+
+```bash
+cf-warp --license 1a2b3d4e-1a2b3d4e-1a2b3d4e #Your own license key goes here
+```
+
+3. When done, the current config should be sharing the same data quota as the mobile 1.1.1.1
+    - If you've paid on your phone, this config should enjoy unlimited data and WARP+.
+
 ## Thanks
 
 https://github.com/yyuueexxiinngg/some-scripts/tree/master/cloudflare

--- a/cli.js
+++ b/cli.js
@@ -8,6 +8,7 @@ const register = require('./lib/register')
 const info = require('./lib/info')
 const ref = require('./lib/ref')
 const conf = require('./lib/conf')
+const license = require('./lib/license')
 
 const args = process.argv.slice(2)
 const HOME = os.homedir()
@@ -73,15 +74,35 @@ async function init() {
 		)
 		await write('cf-warp.conf', conf(data))
 	}
-	const n = parseInt(args[0])
-	if (!isNaN(n)) {
-		console.log(`Prepare faking Warp+ referrer for ${n} times.`)
-		for (let i = 1; i <= n; i++) {
-			await sleep(20000)
-			await ref(data)
-			console.log(`#${i} fake referrer finished`)
+
+	if (args[0] === '--license') {
+		// License
+		const licenseStr = args[1]
+		if (!licenseStr) {
+			console.log('Please provide a valid license string from your app.')
+			console.log('Example: cf-warp --license 1a2b3d4e-1a2b3d4e-1a2b3d4e')
+			return
 		}
+		console.log(
+			`Trying to register your device under the license "${licenseStr}"`
+		)
+		await license({ ...data, license: licenseStr })
+		console.log(
+			'Done. You may now manage your device on other devices under the same license.'
+		)
 		console.log()
+	} else {
+		// referrer
+		const n = parseInt(args[0])
+		if (!isNaN(n)) {
+			console.log(`Prepare faking Warp+ referrer for ${n} times.`)
+			for (let i = 1; i <= n; i++) {
+				await sleep(20000)
+				await ref(data)
+				console.log(`#${i} fake referrer finished`)
+			}
+			console.log()
+		}
 	}
 	const newData = await info(data)
 	printInfo(newData)

--- a/lib/license.js
+++ b/lib/license.js
@@ -1,0 +1,26 @@
+const request = require('./https-request')
+
+module.exports = async ({ id, token, license }) => {
+	const json = await request(
+		`https://api.cloudflareclient.com/v0a977/reg/${id}/account`,
+		'PUT',
+		{
+			'User-Agent': 'okhttp/3.12.1',
+			Authorization: `Bearer ${token}`
+		},
+		JSON.stringify({
+			license
+		})
+    )
+    const data = JSON.parse(json)
+    if(data.success === false) {
+        throw new Error(`${data.errors[0].message}(${data.errors[0].code})`);
+    }
+	return data
+}
+if (require.main === module) {
+	require('get-stdin')()
+		.then(JSON.parse)
+		.then(module.exports)
+		.then(r => console.log(JSON.stringify(r, null, 2)))
+}


### PR DESCRIPTION
Adds support for license binding with other existing devices.
This links to existing WARP+ reward data and WARP+ UNLIMITED subscription
Usage:
```
cf-warp --license 1a2b3d4e-1a2b3d4e-1a2b3d4e
```