### PR TITLE
Avoid using tls1.1 in OpenSSL 3.0+

### DIFF
--- a/lib/https-request.js
+++ b/lib/https-request.js
@@ -1,11 +1,20 @@
 const https = require('https')
 
+// TLS1.1 or lower is not usable in OpenSSL 3.0+
+function sslCompat() {
+	const openSSLMajor = Number(process.versions.openssl[0])
+	if (openSSLMajor < 3) {
+		return {secureProtocol: 'TLSv1_1_method'}
+	}
+	return {}
+}
+
 module.exports = (url, method, headers, body) =>
 	new Promise((resolve, reject) => {
 		const request = https.request(url, {
 			headers,
 			method,
-			secureProtocol: 'TLSv1_1_method'
+			...sslCompat()
 		})
 		request.end(body)
 		request.on('response', response => {


### PR DESCRIPTION
tls1.1 or lower is not usable by default since OpenSSL 3.0 used in Nodejs 17+. Tested on Nodejs 14, 16, 18.

`{minVersion: 'TLSv1.1'}` or `{maxVersion: 'TLSv1.1'}` doesn't work for <=Nodejs 16.
Setting both does work for <=Nodejs 16, but not Nodejs 17+.

Fixes #32 